### PR TITLE
Prevent drawing while a screenshot is being taken

### DIFF
--- a/DisplayEnergy/ModEntry.cs
+++ b/DisplayEnergy/ModEntry.cs
@@ -45,7 +45,7 @@ namespace dmarcoux.Stardew.DisplayEnergy
                 energyTextOffset = energyTextOffset with { X = x + 50 };
             }
 
-            if (!Game1.eventUp)
+            if (!Game1.eventUp && !Game1.game1.takingMapScreenshot)
             {
                 Game1.spriteBatch.DrawString(Game1.dialogueFont, $"{(int)Game1.player.Stamina}/{Game1.player.maxStamina}", new Vector2(Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea().Right - energyTextOffset.X, Game1.graphics.GraphicsDevice.Viewport.GetTitleSafeArea().Bottom - energyTextOffset.Y), Color.White);
             }


### PR DESCRIPTION
Hi! This fixes an issue where the energy numbers show up on screenshots. I've added a check to not draw on screen if a screenshot is being taken.

Let me know if you need me to do anything differently regarding this PR, but I've just updated the one line that needed the change. Thanks!

Before adding the change (I added red circles around a couple of examples of the numbers that appeared):
![01-01-13-before](https://github.com/user-attachments/assets/e4672d82-f703-41fc-a608-507ede37c82e)

After adding the change (no more numbers on the screenshot):
![01-01-13-after](https://github.com/user-attachments/assets/e1ab2f26-6c59-427b-8f0e-8fb54d8e2dbd)
